### PR TITLE
feat: add separate links format

### DIFF
--- a/src/scrape.ts
+++ b/src/scrape.ts
@@ -12,6 +12,8 @@ export interface ScrapeOptions {
    * Output formats for scraping
    * - 'markdown': Page content in markdown format
    * - 'html': Page content in HTML format
+   * - 'text': Plain text content
+   * - 'links': All hyperlinks on the page
    * - 'screenshot-visible': Screenshot of visible viewport
    * - 'screenshot-fullpage': Full page screenshot
    *

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -8,7 +8,7 @@
 
 export type RobotType = 'extract' | 'scrape' | 'crawl' | 'search';
 export type RobotMode = 'normal' | 'bulk';
-export type Format = 'markdown' | 'html' | 'screenshot-visible' | 'screenshot-fullpage';
+export type Format = 'markdown' | 'html' | 'text' | 'links' | 'screenshot-visible' | 'screenshot-fullpage';
 export type RunStatus = 'running' | 'queued' | 'success' | 'failed' | 'aborting' | 'aborted';
 export type TimeUnit = 'MINUTES' | 'HOURS' | 'DAYS' | 'WEEKS' | 'MONTHS';
 export type CrawlMode = 'domain' | 'subdomain' | 'path';
@@ -126,6 +126,7 @@ export interface RunResult {
     text?: string;
     markdown?: string;
     html?: string;
+    links?: string[];
     promptResult?: string | null;
     binaryOutput?: Record<string, string>;
   };


### PR DESCRIPTION
What this PR does?

Registers "Links" as a separate configurable format for all scrape-like robot types.